### PR TITLE
Add dynamic variable option to frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,8 @@ services:
     networks:
       - storedog-backend_storedog-net
     environment:
-      - "DD_CLIENT_TOKEN=${DD_CLIENT_TOKEN}"
+      - "NEXT_PUBLIC_DD_CLIENT_TOKEN=${DD_CLIENT_TOKEN}"
+      - "NEXT_PUBLIC_DD_APPLICATION_ID=${APP_ID}"
   nginx:
     build:
       context: ./services/nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - 3000:3000
     networks:
       - storedog-backend_storedog-net
+    environment:
+      - "DD_CLIENT_TOKEN=${DD_CLIENT_TOKEN}"
   nginx:
     build:
       context: ./services/nginx

--- a/services/frontend/site/next.config.js
+++ b/services/frontend/site/next.config.js
@@ -18,7 +18,8 @@ module.exports = withCommerceConfig({
     defaultLocale: 'en-US',
   },
   env: {
-    NEXT_PUBLIC_DD_CLIENT_TOKEN: process.env.DD_CLIENT_TOKEN
+    NEXT_PUBLIC_DD_APPLICATION_ID: process.env.NEXT_PUBLIC_DD_APPLICATION_ID,
+    NEXT_PUBLIC_DD_CLIENT_TOKEN: process.env.NEXT_PUBLIC_DD_CLIENT_TOKEN,
   }  ,
   rewrites() {
     return [

--- a/services/frontend/site/next.config.js
+++ b/services/frontend/site/next.config.js
@@ -17,6 +17,9 @@ module.exports = withCommerceConfig({
     locales: ['en-US', 'es'],
     defaultLocale: 'en-US',
   },
+  env: {
+    NEXT_PUBLIC_DD_CLIENT_TOKEN: process.env.DD_CLIENT_TOKEN
+  }  ,
   rewrites() {
     return [
       (isBC || isShopify || isSwell || isVendure || isSaleor) && {


### PR DESCRIPTION
## Description

Please, provide here a short description.

- Update the docker-compose file to have an environment argument for env vars.
- Update the `next.config.js` file to accept these passed in variables

## How to test

- Pull down this branch
- Run `docker compose build frontend`
- In your `env.local` file copy the values for `NEXT_PUBLIC_DD_CLIENT_TOKEN` and `NEXT_PUBLIC_DD_APPLICATION_ID`
- **DO NOT RUN THIS YET** Type this into your console, replacing `value` with the values from your `local.env` file `DD_CLIENT_TOKEN="{value}" APP_KEY="{value}" docker-compose up`
- Remove the values for `NEXT_PUBLIC_DD_CLIENT_TOKEN` and `NEXT_PUBLIC_DD_APPLICATION_ID` from your `local.env` file
- Run the command previously typed in your CLI
- You should see an output in the terminal with the next.config.js containing your variables
- You should be able to navigate to https://dd-corpsite.datadoghq.com/rum/application/b055dcb4-6da7-451c-94eb-def2b29acd1d/overview/browser?from_ts=1660842182625&to_ts=1660842482625&live=true and see your session running

Depending on how many env vars we will need, there is also a way to do this with a file from the cli as well, but if it's only a handful of arguments I think this solves for the training teams usecase.


## Checklist

Before you move on, make sure that:

- [x] No unintended changes are included
- [x] Spelling is correct
- [ ] There are tests covering new/changed functionality
- [x] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [x] Proper labels assigned. Use `WIP` label to indicate that state
