### PR TITLE
Pin node to v16 in Dockerfile

### DIFF
--- a/services/frontend/Dockerfile
+++ b/services/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts as builder
+FROM node:16.18.0 as builder
 WORKDIR /storedog-app
 COPY . .
 EXPOSE 3000


### PR DESCRIPTION
## Description
Due to node lts going to version 18, some of the packages were failing on yarn install. I've pinned the node version we use in the Dockerfile to `16.18.0`

https://nodejs.org/en/blog/release/v18.12.0/
## How to test

Please describe the steps needed in order to properly test the functionality of this PR

## Checklist

Before you move on, make sure that:

- [ ] No unintended changes are included
- [ ] Spelling is correct
- [ ] There are tests covering new/changed functionality
- [ ] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [ ] Proper labels assigned. Use `WIP` label to indicate that state
